### PR TITLE
Create Release.yml

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,39 @@
+name: Manual Release Zip
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag 名稱（例如 v1.0.0）"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Create Git tag
+        run: |
+          git tag ${{ github.event.inputs.tag }}
+          git push origin ${{ github.event.inputs.tag }}
+
+      - name: Zip project
+        run: |
+          zip -r release.zip . -x "*.git*" "*.github*"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          files: release.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to facilitate manual release creation. The workflow allows users to create a release zip file and tag it with a specified version.

### New GitHub Actions Workflow:

* `.github/workflows/Release.yml`: Added a `workflow_dispatch`-triggered workflow named "Manual Release Zip" that enables users to:
  - Specify a tag name as input.
  - Create a Git tag and push it to the repository.
  - Generate a zipped version of the project, excluding `.git` and `.github` directories.
  - Publish the zip file as part of a GitHub Release using the specified tag.